### PR TITLE
Deprecate hook name `lint`; add hook name `ruff`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,23 @@ jobs:
           git config user.name 'Github Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: pre-commit-mirror --language python --package-name ruff --entry ruff --id lint --types python --description "Run ruff to lint Python files." .
+      - run: >
+          pre-commit-mirror
+            --language python
+            --package-name ruff
+            --entry ruff
+            --id ruff
+            --types python
+            --description "Run `ruff` for extremely fast Python linting" .
+      
+      # Intended for removal November 2022 (1 month after deprecation)
+      - run: >
+          pre-commit-mirror
+            --language python
+            --package-name ruff
+            --entry ruff
+            --id lint
+            --types python
+            --description "Deprecated: use hook id `ruff` instead. Planned removal 2022-11-30" .
 
       - run: git push origin HEAD:refs/heads/main --tags

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,16 @@
+-   id: ruff
+    name: ruff
+    description: 'Run `ruff` for extremely fast Python linting'
+    entry: ruff
+    language: python
+    'types': [python]
+    args: []
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '0'
 -   id: lint
     name: ruff
-    description: 'Run ruff to lint Python files.'
+    description: 'Deprecated: use hook id `ruff` instead. Planned removal 2022-11-30'
     entry: ruff
     language: python
     'types': [python]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ A [pre-commit](https://pre-commit.com/) hook for [ruff](https://github.com/charl
 Distributed as a standalone repository to enable installing ruff via prebuilt wheels from
 [PyPI](https://pypi.org/project/ruff/).
 
+For pre-commit: see https://github.com/pre-commit/pre-commit
+
+For ruff: see https://github.com/charliermarsh/ruff
+
+### Using ruff with pre-commit
+
+Add this to your `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+      - id: ruff
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
- Added a hook name `ruff` that will be used going forward
- Updated description of `lint` to indicate it is deprecated
- Updated workflow producing these hook configurations
- Updated readme to match examples on PyCQA

Resolves #3 