### PR TITLE
Remove deprecated lint task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,5 @@ jobs:
             --id ruff
             --types python
             --description "Run `ruff` for extremely fast Python linting" .
-      
-      # Intended for removal November 2022 (1 month after deprecation)
-      - run: >
-          pre-commit-mirror
-            --language python
-            --package-name ruff
-            --entry ruff
-            --id lint
-            --types python
-            --description "Deprecated: use hook id `ruff` instead. Planned removal 2022-11-30" .
 
       - run: git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
\cc @tgross35 - I think, as implemented, this won't quite do the right thing, since the mirror maker only creates one commit per version (so the second invocation seems to be a no-op). I'm just going to remove it entirely for now, since it's only being applied to new versions anyway.
