### PR TITLE
README: `--force-exclude` is already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Add this to your `.pre-commit-config.yaml`:
   rev: 'v0.0.191'
   hooks:
     - id: ruff
-      # Respect `exclude` and `extend-exclude` settings.
-      args: ["--force-exclude"]
 ```
 
 ## License


### PR DESCRIPTION
Re: https://github.com/charliermarsh/ruff-pre-commit/issues/19 / https://github.com/charliermarsh/ruff-pre-commit/pull/20

If I understand this is now always set, no need to include it in the README example.