### PR TITLE
feat: set `--force-exclude` in `pre-commit-mirror` command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,6 @@ jobs:
           git config user.name 'Github Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: pre-commit-mirror --language python --package-name ruff --entry ruff --id ruff --types-or python --types-or pyi --require-serial --description "Run 'ruff' for extremely fast Python linting" .
+      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff --force-exclude' --id ruff --types-or python --types-or pyi --require-serial --description "Run 'ruff' for extremely fast Python linting" .
 
       - run: git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
https://github.com/charliermarsh/ruff-pre-commit/pull/20 added the flag in pre-commit configuration, but since the source of truth is `pre-commit-mirror` command in the CI workflow, it is replaced by `ruff`, as can be shown in https://github.com/charliermarsh/ruff-pre-commit/commit/380e8f2639b354dd012c1d16391c80a09bf12ffd.