### PR TITLE
Run with `--fix` by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
     entry: ruff --force-exclude
     language: python
     'types_or': [python, pyi]
-    args: []
+    args: [--fix]
     require_serial: true
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'


### PR DESCRIPTION
Most pre-commit hooks apply any changes that need to be made. The task of actually adding (e.g.: `git add`) is left to the user.

This change results in this hook behaving like others. Users will no longer be required to manually run `ruff --fix` afterwards.