### PR TITLE
feat: run `--quiet` by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,6 @@ jobs:
           git config user.name 'Github Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff --force-exclude' --id ruff --types-or python --types-or pyi --require-serial --description "Run 'ruff' for extremely fast Python linting" .
+      - run: pre-commit-mirror --language python --package-name ruff --entry 'ruff --force-exclude' --args=--quiet --id ruff --types-or python --types-or pyi --require-serial --description "Run 'ruff' for extremely fast Python linting" .
 
       - run: git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
This might be a bit opinionated, but in my experience it's quite common to configure pre-commit tools so that they output the bare minimum necessary. This adds `--quiet` to default `args`; it can be overridden in user configs in case more output is wanted.