### PR TITLE
Add a note about recommended hook ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Or, to enable autofix:
       args: [--fix, --exit-non-zero-on-fix]
 ```
 
+Note that Ruff's pre-commit hook should run before Black, isort, and other
+formatting tools.
+
 ## License
 
 MIT


### PR DESCRIPTION
The Ruff documentation remarks that the Ruff pre-commit hook should run before code formatting tools (see https://beta.ruff.rs/docs/usage/). I copied the sentence from the Ruff documentation to the README here to increase its visibility.