### PR TITLE
Quotes around version in README yaml code block are not necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.0.269"
+  rev: v0.0.269
   hooks:
     - id: ruff
 ```
@@ -22,7 +22,7 @@ Or, to enable autofix:
 ```yaml
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.0.269"
+  rev: v0.0.269
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
This is a very minor detail, but maybe worth since a lot of people might copy and paste from here.

The strings around the version in the `.pre-commit-config.yaml` file are not necessary, in YAML quotes are only needed around strings if the they contains spaces or special characters (https://www.yaml.info/learn/quote.html).

Thanks for you work on ruff, this is a game changer app.