### PR TITLE
Add `markdown` to `types_or`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Run 'ruff check' for extremely fast Python linting"
   entry: ruff check --force-exclude
   language: python
-  types_or: [python, pyi, jupyter]
+  types_or: [python, pyi, jupyter, markdown]
   args: []
   require_serial: true
   additional_dependencies: []
@@ -14,7 +14,7 @@
   description: "Run 'ruff format' for extremely fast Python formatting"
   entry: ruff format --force-exclude
   language: python
-  types_or: [python, pyi, jupyter]
+  types_or: [python, pyi, jupyter, markdown]
   args: []
   require_serial: true
   additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Run 'ruff check' for extremely fast Python linting"
   entry: ruff check --force-exclude
   language: python
-  types_or: [python, pyi, jupyter, markdown]
+  types_or: [python, pyi, jupyter]
   args: []
   require_serial: true
   additional_dependencies: []

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ repos:
     - id: ruff-format
 ```
 
+The format hook also formats [Python code blocks in Markdown files](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting).
+
 To enable lint fixes, add the `--fix` argument to the lint hook:
 
 ```yaml
@@ -71,7 +73,7 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-      types_or: [ python, pyi ]
+      types_or: [ python, pyi, markdown ]
 ```
 
 To lint `pyproject.toml`, add `pyproject` to the list of allowed filetypes (requires `identify>=2.6.18`):
@@ -88,7 +90,7 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-      types_or: [ python, pyi, jupyter ]
+      types_or: [ python, pyi, jupyter, markdown ]
 ```
 
 When running with `--fix`, Ruff's lint hook should be placed _before_ Ruff's formatter hook, and
@@ -116,7 +118,7 @@ hooks = [
   { id = "ruff-check", args = ["--fix"], types_or = ["python", "pyi"] },
 
   # Run the formatter.
-  { id = "ruff-format", types_or = ["python", "pyi"] },
+  { id = "ruff-format", types_or = ["python", "pyi", "markdown"] },
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ repos:
     - id: ruff-format
 ```
 
-The format hook also formats [Python code blocks in Markdown files](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting).
+By default, the format hook also formats [Python code blocks in Markdown files](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting).
 
 To enable lint fixes, add the `--fix` argument to the lint hook:
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Now `*.md` files are in `tool.ruff.include` by default and may be used with `tool.ruff.format.preview = True`, etc.

https://docs.astral.sh/ruff/settings/#include

https://github.com/astral-sh/ruff/pull/23434/changes/4795ecacad88fe9be565c795317df318903314a4#diff-959aaaf28345388cb476e91b1a8b127625bffba0ca2f8ed794f687bd27e50302

## Test Plan

<!-- How was it tested? -->
```yaml
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.15.5
    hooks:
      - id: ruff-format
        types_or: [python, pyi, jupyter, markdown]
```
