### PR TITLE
Create releases for all new mirror tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,12 @@ jobs:
       - name: create release on new tag if new changes exist
         if: env.changes_exist == 'true'
         run: |
-          TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))
-          echo $TAG_NAME
-          gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME/v}" \
-            --latest
+          for TAG_NAME in $(git log --reverse --format=%H origin/main..HEAD | xargs -r -n1 git tag --points-at); do
+            echo "$TAG_NAME"
+            gh release create "$TAG_NAME" \
+              --title "$TAG_NAME" \
+              --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME/v}" \
+              --latest
+          done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #128.

When the mirror script creates more than one commit/tag in a run, the workflow was only creating a GitHub release for the latest tag. This changes the release step to walk the new commits from `origin/main..HEAD` and create a release for each tag on those commits.

The loop uses `--reverse` so older tags are released first and the newest tag remains the latest release at the end.

Checked with:
- parsed `.github/workflows/main.yml` with PyYAML
- a small local git repo simulation that produced `v1` then `v2` from the new tag lookup command
- `git diff --check`