### PR TITLE
Document rule selection args

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ When using inline YAML lists, quote arguments that contain commas:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.12
+  rev: v0.15.13
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ repos:
     - id: ruff-format
 ```
 
+To select or ignore specific rules, pass the relevant Ruff arguments through `args`.
+When using inline YAML lists, quote arguments that contain commas:
+
+```yaml
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.15.12
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: [ --fix, "--extend-select=I,E", "--ignore=F401" ]
+```
+
 To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed filetypes:
 
 ```yaml


### PR DESCRIPTION
Closes #107.

Adds a short README example for passing rule-selection options through the Ruff hook args, including quoted comma-separated values in inline YAML.

Checks: git diff --check; parsed the YAML example.