### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+Security issues for this repository follow Ruff's security policy.
+
+Please report vulnerabilities through the private reporting process described in
+Ruff's `SECURITY.md`:
+
+https://github.com/astral-sh/ruff/blob/main/SECURITY.md
+
+Do not report security vulnerabilities through public GitHub issues.


### PR DESCRIPTION
Closes #115.

Adds a short SECURITY.md that points security reports to Ruff's existing private reporting process.

Checks: git diff --check.