### PR TITLE
Various hardenings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     - cron: "0 */4 * * *"
   workflow_dispatch:
-  repository_dispatch:
-    types: [pypi_release]
 
 permissions: {}
 
@@ -15,9 +13,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - if: ${{ startsWith(github.event_name, 'repository_dispatch') }}
-        run: sleep 30
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: true # needed to push commits below
@@ -38,10 +33,10 @@ jobs:
           UNPUSHED_COMMITS=$(git log origin/main..HEAD)
           if [ -z "$UNPUSHED_COMMITS" ]; then
             echo "No unpushed commits found."
-            echo "changes_exist=false" >> $GITHUB_ENV
+            echo "changes_exist=false" >> "$GITHUB_ENV"
           else
             echo "Unpushed commits found."
-            echo "changes_exist=true" >> $GITHUB_ENV
+            echo "changes_exist=true" >> "$GITHUB_ENV"
           fi
 
       - name: push changes if they exist
@@ -53,8 +48,8 @@ jobs:
       - name: create release on new tag if new changes exist
         if: env.changes_exist == 'true'
         run: |
-          TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))
-          echo $TAG_NAME
+          TAG_NAME=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+          echo "$TAG_NAME"
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes "See: https://github.com/astral-sh/ruff/releases/tag/${TAG_NAME/v}" \


### PR DESCRIPTION
## Summary

- Fix actionlint warnings (from its shellcheck integration) due to various variables not being quoted in `main.yml`
- Remove the `repository_dispatch` trigger in `main.yml`. The Ruff workflow that triggers new releases in this repository has used `workflow_dispatch` since 2023: https://github.com/astral-sh/ruff/pull/4598.
- Add a dependabot cooldown to fix zizmor warnings.

I will apply these changes to our other pre-commit repos too, if this is accepted.
