### PR TITLE
fix: update prek rev in README.md during mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ equivalent to the `.pre-commit-config.yaml` configuration:
 ```toml
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.0" # Ruff version.
+rev = "v0.15.18" # Ruff version.
 hooks = [
   # Run the linter.
   { id = "ruff-check", args = ["--fix"], types_or = ["python", "pyi"] },

--- a/mirror.py
+++ b/mirror.py
@@ -64,6 +64,7 @@ def process_version(version: Version) -> typing.Sequence[str]:
 
     def replace_readme_md(content: str) -> str:
         content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{version}", content)
+        content = re.sub(r'rev = "v\d+\.\d+\.\d+"', f'rev = "v{version}"', content)
         return re.sub(r"/ruff/\d+\.\d+\.\d+\.svg", f"/ruff/{version}.svg", content)
 
     paths = {


### PR DESCRIPTION
Closes #171

## Problem

`mirror.py` updates all pre-commit YAML-style `rev:` entries in `README.md` but silently skips the prek TOML-style `rev =` entry. After many mirror runs the prek block drifted 18 releases behind:

```toml
rev = "v0.15.0"  # ← never updated
```

while all pre-commit blocks showed the current version:

```yaml
rev: v0.15.18  # ← correctly updated
```

## Root cause

`replace_readme_md` matched `rev: v\d+…` (colon, no quotes) but not `rev = "v\d+…"` (equals + quotes).

## Fix

One additional `re.sub` call in `replace_readme_md`:

```python
content = re.sub(r'rev = "v\d+\.\d+\.\d+"', f'rev = "v{version}"', content)
```

The second commit also corrects the currently stale `rev = "v0.15.0"` in `README.md` to `v0.15.18`.

---

> **Note:** Tools like [repo-release-tools](https://github.com/Anselmoo/repo-release-tools) can help prevent this class of bug by declaring all version string locations as `pin_targets` in `pyproject.toml` — if a location is missing from the config, `rrt release check` flags it before it can drift.